### PR TITLE
Fix failing tests

### DIFF
--- a/lib/ThePlaid/Model.hs
+++ b/lib/ThePlaid/Model.hs
@@ -12802,6 +12802,15 @@ instance A.FromJSON PersonalFinanceCategory where
       <$> (o .: "primary")
       <*> (o .: "detailed")
 
+-- | ToJSON PersonalFinanceCategory
+instance A.ToJSON PersonalFinanceCategory where
+  toJSON PersonalFinanceCategory {..} =
+   _omitNulls
+      [ "primary" .= personalFinanceCategoryPrimary
+      , "detailed" .= personalFinanceCategoryDetailed
+      ]
+
+
 -- | FromJSON Transaction
 instance A.FromJSON Transaction where
   parseJSON = A.withObject "Transaction" $ \o ->
@@ -12854,6 +12863,7 @@ instance A.ToJSON Transaction where
       , "amount" .= transactionAmount
       , "account_id" .= transactionAccountId
       , "transaction_code" .= transactionTransactionCode
+      , "personal_finance_category" .= transactionPersonalFinanceCategory
       ]
 
 

--- a/the-plaid.cabal
+++ b/the-plaid.cabal
@@ -17,7 +17,7 @@ homepage:       https://openapi-generator.tech
 author:         Author Name Here
 maintainer:     author.name@email.com
 copyright:      YEAR - AUTHOR
-license:        UnspecifiedLicense
+license:        OtherLicense
 build-type:     Simple
 cabal-version:  >= 1.10
 
@@ -43,7 +43,7 @@ library
     , containers >=0.5.0.0 && <0.8
     , deepseq >= 1.4 && <1.6
     , exceptions >= 0.4
-    , http-api-data >= 0.3.4 && <0.5
+    , http-api-data >= 0.3.4 && <=0.6.1
     , http-client >= 0.7 && < 0.8
     , http-client-tls
     , http-media >= 0.4 && < 0.9
@@ -54,11 +54,11 @@ library
     , network >=2.6.2 && <3.9
     , random >=1.1
     , safe-exceptions <0.2
-    , text >=0.11 && <1.3
+    , text >=0.11 && <=2.1.2
     , time >=1.5
     , transformers >=0.4.0.0
     , unordered-containers
-    , vector >=0.10.9 && <0.13
+    , vector >=0.10.9 && <=0.13.2.0
   other-modules:
       Paths_the_plaid
   exposed-modules:


### PR DESCRIPTION
Tests were failing because of a missing ToJSON instance for `PersonalFinanceCategory`.

Alongside fixing the transaction tests, allow newer versions of http-api-data, text, and vector in cabal file to match the stack.yaml and use valid cabal license tag. 

